### PR TITLE
use new kraken org prefix for cross-domain-utils

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -3,8 +3,8 @@
 .*/node_modules/flow-runtime
 .*/node_modules/cross-domain-safe-weakmap/dist
 .*/node_modules/cross-domain-safe-weakmap/test
-.*/node_modules/cross-domain-utils/dist
-.*/node_modules/cross-domain-utils/test
+.*/node_modules/@krakenjs/cross-domain-utils/dist
+.*/node_modules/@krakenjs/cross-domain-utils/test
 .*/node_modules/npm
 .*/node_modules/jsonlint
 .*/node_modules/resolve

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
   "author": "Steve Mask",
   "license": "Apache-2.0",
   "dependencies": {
+    "@krakenjs/cross-domain-utils": "^3.0.2",
     "@paypal/sdk-constants": "^1.0.113",
     "beaver-logger": "^4.0.32",
     "belter": "^1.0.146",
     "bowser": "^2.0.0",
-    "cross-domain-utils": "^2.0.38",
     "jsx-pragmatic": "^2.0.22",
     "zalgo-promise": "^1.0.48"
   },

--- a/src/domains.js
+++ b/src/domains.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { getActualDomain } from 'cross-domain-utils/src';
+import { getActualDomain } from '@krakenjs/cross-domain-utils/src';
 
 import { URI } from './config';
 


### PR DESCRIPTION
`cross-domain-utils` -> `@krakenjs/cross-domain-utils`

no code changes